### PR TITLE
add ld-linux.so (armhf and aarch64) to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat
 RUN apt-get install -y libglib2.0-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
+RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross
 RUN apt-get install -y gdb gdbserver openjdk-8-jdk-headless docker.io
 RUN apt-get install -y strace
 RUN pip3 install "virtualenv<20" pygithub


### PR DESCRIPTION
needed for patcherex's aarch64/arm tests

https://github.com/angr/patcherex/blob/arm/tests/test_detourbackend_aarch64.py#L258
https://github.com/angr/patcherex/blob/arm/tests/test_detourbackend_arm.py#L258