### PR TITLE
add ld-linux.so for mips64, remove binutils for {mips, arm, aarch64}

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat
 RUN apt-get install -y libglib2.0-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
-RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross binutils-arm-linux-gnueabihf binutils-aarch64-linux-gnu binutils-mips-linux-gnu
+RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross libc6-mips64-cross
 RUN apt-get install -y gdb gdbserver openjdk-8-jdk-headless docker.io
 RUN apt-get install -y strace
 RUN pip3 install "virtualenv<20" pygithub


### PR DESCRIPTION
 - needed for patcherex's [mips64 tests](https://github.com/angr/patcherex/blob/feat/multiarch/tests/test_detourbackend_mips64.py#L261)

 - {mips, arm, aarch64} binutils are no longer needed https://github.com/angr/patcherex/commit/835deb2f34fbc0244419af6ccbfe98b823c3d5b9