### PR TITLE
add libc6 for powerpc && fix seg fault of qemu-user(big-endian)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,15 @@ RUN apt-get install -y gdb gdbserver openjdk-8-jdk-headless docker.io
 RUN apt-get install -y strace
 RUN pip3 install "virtualenv<20" pygithub
 
+# This command is used to fix problems with libc6-cross packages
+# this is only a temporary solution and should be fixed in the ubuntu packages in the future
+# more detail can be found at angr/ci-settings#11 and bugs.launchpad.net/qemu/+bug/1701798
+RUN mkdir /usr/mips-linux-gnu/etc /usr/mips64-linux-gnuabi64/etc /usr/powerpc-linux-gnu/etc /usr/powerpc64-linux-gnu/etc \
+    && ln -s /dev/null /usr/mips-linux-gnu/etc/ld.so.cache \
+    && ln -s /dev/null /usr/mips64-linux-gnuabi64/etc/ld.so.cache \
+    && ln -s /dev/null /usr/powerpc-linux-gnu/etc/ld.so.cache \
+    && ln -s /dev/null /usr/powerpc64-linux-gnu/etc/ld.so.cache
+
 RUN umask 0; git clone https://github.com/angr/wheels.git
 ADD scripts ./scripts
 ADD conf ./conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat
 RUN apt-get install -y libglib2.0-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
-RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross libc6-mips64-cross
+RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross libc6-mips64-cross libc6-powerpc-cross libc6-powerpc-ppc64-cross
 RUN apt-get install -y gdb gdbserver openjdk-8-jdk-headless docker.io
 RUN apt-get install -y strace
 RUN pip3 install "virtualenv<20" pygithub

--- a/docker/scripts/azure-build.sh
+++ b/docker/scripts/azure-build.sh
@@ -5,6 +5,13 @@ SCRIPTS=$BASEDIR/scripts
 CONF=$BASEDIR/conf
 WHEELS=$BASEDIR/wheels
 
+mkdir /usr/mips-linux-gnu/etc /usr/mips64-linux-gnuabi64/etc /usr/powerpc-linux-gnu/etc /usr/powerpc64-linux-gnu/etc
+
+ln -s /dev/null /usr/mips-linux-gnu/etc/ld.so.cache
+ln -s /dev/null /usr/mips64-linux-gnuabi64/etc/ld.so.cache
+ln -s /dev/null /usr/powerpc-linux-gnu/etc/ld.so.cache
+ln -s /dev/null /usr/powerpc64-linux-gnu/etc/ld.so.cache
+
 cd $WHEELS
 git fetch
 git reset --hard $BUILD_SOURCEBRANCH || true

--- a/docker/scripts/azure-build.sh
+++ b/docker/scripts/azure-build.sh
@@ -5,13 +5,6 @@ SCRIPTS=$BASEDIR/scripts
 CONF=$BASEDIR/conf
 WHEELS=$BASEDIR/wheels
 
-mkdir /usr/mips-linux-gnu/etc /usr/mips64-linux-gnuabi64/etc /usr/powerpc-linux-gnu/etc /usr/powerpc64-linux-gnu/etc
-
-ln -s /dev/null /usr/mips-linux-gnu/etc/ld.so.cache
-ln -s /dev/null /usr/mips64-linux-gnuabi64/etc/ld.so.cache
-ln -s /dev/null /usr/powerpc-linux-gnu/etc/ld.so.cache
-ln -s /dev/null /usr/powerpc64-linux-gnu/etc/ld.so.cache
-
 cd $WHEELS
 git fetch
 git reset --hard $BUILD_SOURCEBRANCH || true


### PR DESCRIPTION
**add libc6 for powerpc**
https://github.com/angr/patcherex/blob/feat/multiarch/tests/test_detourbackend_mips.py#L261

**fix seg fault of qemu-user(big-endian)**
qemu-user will crash for big-endian targets, because _the the format of ld.so.cache is **not** endian-agnostic and ld.so.cache with wrong endianness will cause the crash._ So I created empty ld.so.cache files in QEMU_LD_PREFIX directories to prevent this problem from happening.

more details can be found [here](https://bugs.launchpad.net/qemu/+bug/1701798)