### PR TITLE
add lld (LLVM linker)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN chmod 755 .
 # install deps. make sure not to create too-large layers
 RUN dpkg --add-architecture i386
 RUN apt-get update
-RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat
+RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat lld
 RUN apt-get install -y libglib2.0-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
 RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross libc6-mips64-cross libc6-powerpc-cross libc6-powerpc-ppc64-cross
 RUN apt-get install -y gdb gdbserver openjdk-8-jdk-headless docker.io


### PR DESCRIPTION
angr/patcherex requires lld for the new ReplaceFunctionPatch 
(llvm linker works for all architectures, so we don't have to install binutils for all architectures)

https://github.com/angr/patcherex/blob/feat/multiarch/patcherex/backends/detourbackends/aarch64.py#L543