### PR TITLE
Publish API docs to angr-doc repo gh-pages branch

### DIFF
--- a/scripts/publish_api_docs.sh
+++ b/scripts/publish_api_docs.sh
@@ -1,17 +1,21 @@
+#!/bin/bash
+# Update gh-pages branch on the angr-doc repository for
+# API doc publishing at https://api.angr.io via GitHub Pages
 set -ex
 
-# Clone website repo
-git clone git@github.com:angr/angr.github.io.git angr.github.io
+git clone -b gh-pages git@github.com:angr/angr-doc.git
+pushd angr-doc
 
-# Replace api-doc with new version
-rm -rf angr.github.io/api-doc
-cp -r apidocs angr.github.io/api-doc
+git rm -rf *
+cp -r ../apidocs/* .
 
-# Push to website
-git -C angr.github.io commit api-doc \
-    --author "angr release bot <angr-dev@asu.edu>" \
-    --message "update api-docs for version $angr_doc_version"
+echo "api.angr.io" > CNAME
+
+git add .
+git commit --allow-empty \
+           --author "angr release bot <angr-dev@asu.edu>" \
+           --message "Update api-docs for version $angr_doc_version"
 
 if [ "$DRY_RUN" == "false" ]; then
-    git -C angr.github.io push origin master
+    git push -f origin gh-pages:gh-pages
 fi


### PR DESCRIPTION
This migrates publishing of API docs from the https://github.com/angr/angr.github.io repo `api-doc` subdirectory to the https://github.com/angr/angr-doc repo as an orphan branch `gh-pages` to be served at https://api.angr.io.

I have already run this new script locally to push the version of API docs hosted at https://github.com/angr/angr.github.io in `api-doc` as a commit to the angr-doc repo `gh-pages` branch to preserve current documentation; it runs as expected so I do not expect interruption with the CI/release flow because of this change.

Note: In original script (and this one) `angr_doc_version` variable appears to not be set correctly based on history of https://github.com/angr/angr.github.io/tree/master/api-doc. That issue is not solved here.
