### PR TITLE
fix patcherex issues

### DIFF
--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -25,6 +25,9 @@ RUN mkdir /usr/mips-linux-gnu/etc /usr/mips64-linux-gnuabi64/etc /usr/powerpc-li
     && ln -s /dev/null /usr/mips64-linux-gnuabi64/etc/ld.so.cache \
     && ln -s /dev/null /usr/powerpc-linux-gnu/etc/ld.so.cache \
     && ln -s /dev/null /usr/powerpc64-linux-gnu/etc/ld.so.cache
+    
+# fix missing libreadline.so.7
+RUN ln -s /lib/x86_64-linux-gnu/libreadline.so /lib/x86_64-linux-gnu/libreadline.so.7
 
 # Disable pwntools curses
 ENV PWNLIB_NOTERM=1

--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -17,15 +17,6 @@ RUN apt-get install -y fontconfig
 RUN apt-get install -y gcc-multilib g++-multilib
 RUN pip3 install "virtualenv<20" pygithub
 
-# This command is used to fix problems with libc6-cross packages
-# this is only a temporary solution and should be fixed in the ubuntu packages in the future
-# more detail can be found at angr/ci-settings#11 and bugs.launchpad.net/qemu/+bug/1701798
-RUN mkdir /usr/mips-linux-gnu/etc /usr/mips64-linux-gnuabi64/etc /usr/powerpc-linux-gnu/etc /usr/powerpc64-linux-gnu/etc \
-    && ln -s /dev/null /usr/mips-linux-gnu/etc/ld.so.cache \
-    && ln -s /dev/null /usr/mips64-linux-gnuabi64/etc/ld.so.cache \
-    && ln -s /dev/null /usr/powerpc-linux-gnu/etc/ld.so.cache \
-    && ln -s /dev/null /usr/powerpc64-linux-gnu/etc/ld.so.cache
-    
 # fix missing libreadline.so.7
 RUN ln -s /lib/x86_64-linux-gnu/libreadline.so /lib/x86_64-linux-gnu/libreadline.so.7
 


### PR DESCRIPTION
1. One of the test binaries in patcherex is compiled under ubuntu 18 with libreadline.so.7, which is no longer available in ubuntu 20 (ubuntu 20 uses libreadline.so.8), so I added a symbolic link to make it work.

This should fix `test_countdown_1` `test_countdown_2` `test_countdown_3` in 
https://github.com/angr/archinfo/runs/6480224914


2. The tricks used to fix #11 are no longer necessary for Ubuntu 20.
