### PR TITLE
add libreadline package

### DIFF
--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -8,7 +8,7 @@ RUN chmod 755 .
 RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y vim build-essential python3 python3-dev python3-pip python3-setuptools zip git libffi-dev libtool libtool-bin wget automake bison cmake nasm clang socat lld
-RUN apt-get install -y libglib2.0-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
+RUN apt-get install -y libglib2.0-dev libreadline-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
 RUN apt-get install -y libc6-armhf-cross libc6-arm64-cross libc6-mips-cross libc6-mips64-cross libc6-powerpc-cross libc6-powerpc-ppc64-cross
 RUN apt-get install -y gdb gdbserver gdb-multiarch openjdk-8-jdk-headless docker.io libgl1
 RUN apt-get install -y binutils-mips-linux-gnu binutils-mipsel-linux-gnu binutils-arm-linux-gnueabi


### PR DESCRIPTION
This is related to #37 

The solution was to add a link `libreadline.so.7 -> libreadline.so`, but it seems ubuntu 20 image only has libreadline.so.8 and the file libreadline.so doesn't exists. To solve this issue I added the libreadline-dev package, which creates a link `libreadline.so -> libreadline.so.8`  and therefore solves the issue.