### PR TITLE
Update cibuildwheel to 2.11.2

### DIFF
--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -9,7 +9,7 @@ function realpath() {
 
 sdist_path="$(realpath "$1")"
 
-python -m pip install build cibuildwheel==2.3.1
+python -m pip install build cibuildwheel==2.11.2
 if [ "$(uname)" == "Linux" ]; then
     pip install auditwheel
 elif [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
This improved error output which aided in debugging why today's release failed initially.