### PR TITLE
Fix exception names in pylintrc

### DIFF
--- a/ci-image/conf/pylintrc
+++ b/ci-image/conf/pylintrc
@@ -244,4 +244,4 @@ valid-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
Remove warning for
```
UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.
```