### PR TITLE
Install bintrace

### DIFF
--- a/ci-image/Dockerfile
+++ b/ci-image/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get install -y fontconfig
 RUN apt-get install -y gcc-multilib g++-multilib
 RUN apt-get install -y libxkbcommon-dev libegl-dev
 RUN apt-get install -y zstd
+RUN apt-get install -y ninja-build ccache flatbuffers-compiler libflatbuffers-dev
 RUN pip3 install "virtualenv<20" pygithub
 
 # fix missing libreadline.so.7

--- a/ci-image/conf/install.sh.template
+++ b/ci-image/conf/install.sh.template
@@ -9,7 +9,10 @@ cp $CONF/nose2.cfg .
 
 python3 -mvirtualenv --python=`which python3` ./virtualenv
 source ./virtualenv/bin/activate
-pip install -U 'pip==21.3.1' 'setuptools<64'
+pip install -U 'pip==21.3.1' 'setuptools<64' pybind11
+
+pip install --no-build-isolation 'git+https://github.com/mborgerson/bintrace@abad752#egg=bintrace'
+pip install --no-build-isolation 'git+https://github.com/mborgerson/bintrace@abad752#egg=bintrace-qemu&subdirectory=bintrace-qemu'
 
 pip install --requirement ./requirements.txt --no-cache --src ./src --no-build-isolation
 pip freeze > freeze.txt


### PR DESCRIPTION
- For archr tests and beyond, install bintrace with qemu tracer. Currently this will build qemu-i386 from source, but the increase in container build time is not substantial.
- Install deps are not placed into requirements.txt template because pip has issues with cross-package dependencies installed this way.
- Eventually I plan for bintrace to get proper packages on pypi, so this is a temporary fix to get the tests running.
- Pinned bintrace to current repository master branch HEAD.

Related https://github.com/angr/archr/issues/126