### PR TITLE
pylintrc: disable some type-checking

### DIFF
--- a/ci-image/conf/pylintrc
+++ b/ci-image/conf/pylintrc
@@ -55,6 +55,8 @@ disable=
     too-many-statements,
     unidiomatic-typecheck,
     consider-using-f-string,
+    arguments-differ,
+    signature-differs,
 
 
 [REPORTS]


### PR DESCRIPTION
pylint should not try to do type checking. we have a real type checker now.

These lints are additionally subject to a longstanding bug: https://github.com/pylint-dev/pylint/issues/5264