### PR TITLE
Pin wheel==0.45.1

### DIFF
--- a/ci-image/conf/install.sh.template
+++ b/ci-image/conf/install.sh.template
@@ -9,7 +9,7 @@ cp $CONF/nose2.cfg .
 
 python3 -mvirtualenv --python=`which python3` ./virtualenv
 source ./virtualenv/bin/activate
-pip install -U 'pip==21.3.1' 'setuptools<64' setuptools-rust maturin
+pip install -U 'pip==21.3.1' 'setuptools<64' 'wheel==0.45.1' setuptools-rust maturin
 
 pip install --requirement ./requirements.txt --no-cache --src ./src --no-build-isolation
 pip freeze > freeze.txt


### PR DESCRIPTION
Wheel has updated recently, which apparently breaks compatibility with the pip/setuptools combination we've pinned and has taken down our CI. Pin wheel to 0.45.1 to get things working again with minimal changes.

Ultimately I think we should start using uv and latest setuptools, which I've proposed in #56. In the mean time, I'll merge this to unbreak CI.