### PR TITLE
Skip corpus upload if token is unavailable

### DIFF
--- a/.github/workflows/angr-ci.yml
+++ b/.github/workflows/angr-ci.yml
@@ -150,7 +150,7 @@ jobs:
             -F text="Link to failed run: $BUILD_URL"
 
       - name: Trigger corpus upload
-        if: needs.build.result == 'success' && needs.corpus-test.result == 'success'
+        if: needs.build.result == 'success' && needs.corpus-test.result == 'success' && vars.SNAPSHOTS_DISPATCH_TOKEN != ''
         uses: benc-uk/workflow-dispatch@v1.2.4
         with:
           workflow: "angr-corpus-upload.yml"


### PR DESCRIPTION
PRs submitted from forks are failing due to missing secrets. We can fix this with some more automation, but in the mean time let's stop failing CI because of this.